### PR TITLE
Adding PdfCopy that Unembeds Fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.class
+*.jar
+/build/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Beginning with version 5.0 the developers have moved to the AGPL to improve their ability to sell commercial licenses. I fully respect the developers' wishes and rights. To assist those desiring to stick with the old license I'm making the final MPL/LGPL version more easily available.
 
+## Unembedding Fonts ##
+
+This version of iText adds a new type of PdfCopy, UnembedFontPdfSmartCopy, that unembeds all embedded fonts. Its main purpose is to save space by unembedding fonts. 
+
 ## [Javadocs](http://ymasory.github.com/iText-4.2.0/) ##
 
 ## Download ##

--- a/src/core/com/lowagie/text/pdf/UnembedFontPdfSmartCopy.java
+++ b/src/core/com/lowagie/text/pdf/UnembedFontPdfSmartCopy.java
@@ -1,0 +1,44 @@
+package com.lowagie.text.pdf;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Iterator;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+
+/**
+ * Makes a copy of a PDF, unembedding all embedded fonts. All font headers and descriptors are preserved and only the font file is removed.
+ */
+public class UnembedFontPdfSmartCopy extends PdfSmartCopy {
+	
+	public UnembedFontPdfSmartCopy(Document document, OutputStream os)
+			throws DocumentException {
+		super(document, os);
+	}
+
+	protected PdfDictionary copyDictionary(PdfDictionary in)
+        throws IOException, BadPdfFormatException {
+
+		PdfDictionary out = new PdfDictionary();
+		PdfObject type = PdfReader.getPdfObjectRelease(in.get(PdfName.TYPE));
+
+		for (Iterator it = in.getKeys().iterator(); it.hasNext();) {
+			PdfName key = (PdfName) it.next();
+			PdfObject value = in.get(key);
+
+            if (PdfName.FONTFILE.equals(key)
+                    || PdfName.FONTFILE2.equals(key)
+                    || PdfName.FONTFILE3.equals(key))
+            {
+                continue;
+            }
+            else
+            {
+                out.put(key, copyObject(value));
+            }
+		}
+
+		return out;
+	}
+}


### PR DESCRIPTION
I had recently worked on something that required us to unembed fonts from PDFs for the purposes of saving space. I ended up creating a new class that inherits from PdfSmartCopy: UnembedFontPdfSmartCopy, instances of this class will skip copying all FONTFILES. Other than that, they will behave just like PdfSmartCopy
